### PR TITLE
feat(cli): Add transformer option to CLI and support type definitions in the same file

### DIFF
--- a/src/lib/transform-type-names.ts
+++ b/src/lib/transform-type-names.ts
@@ -47,3 +47,47 @@ export function transformTypeNames(
 
   return output;
 }
+
+// New transformer: strips schema prefix and overwrites on conflict
+export function transformTypeNamesStripSchema(sourceText: string) {
+  const sourceFile = ts.createSourceFile(
+    'temp.ts',
+    sourceText,
+    ts.ScriptTarget.Latest,
+    true,
+  );
+
+  // Helper to strip schema prefix (PascalCase, e.g., 'PublicUser' -> 'User')
+  function stripSchemaPrefix(name: string): string {
+    // Remove leading capitalized word (schema) if followed by another capital
+    return name.replace(/^[A-Z][a-z0-9]+(?=[A-Z])/, '');
+  }
+
+  // Collect type alias declarations, keeping only the latest for each name
+  const typeMap = new Map<string, ts.TypeAliasDeclaration>();
+
+  sourceFile.forEachChild((node) => {
+    if (ts.isTypeAliasDeclaration(node)) {
+      const newName = stripSchemaPrefix(node.name.text);
+      // Always overwrite: latest wins
+      typeMap.set(
+        newName,
+        ts.factory.updateTypeAliasDeclaration(
+          node,
+          node.modifiers,
+          ts.factory.createIdentifier(newName),
+          node.typeParameters,
+          node.type,
+        ),
+      );
+    }
+  });
+
+  // Print all unique type aliases (latest wins)
+  const printer = ts.createPrinter({ newLine: ts.NewLineKind.LineFeed });
+  const output = Array.from(typeMap.values())
+    .map((node) => printer.printNode(ts.EmitHint.Unspecified, node, sourceFile))
+    .join('\n\n');
+
+  return output;
+}


### PR DESCRIPTION
- Introduced a new CLI option for custom type name transformers, exposing the current transformer logic.
- Improved type handling to provide flexibility in schema file management, allowing users to append types to the existing schema or generate them in a separate file.
- Implemented a built-in transformer to remove schema prefixes from type names.
- Expanded test coverage to validate the new functionality and ensure accurate type generation.